### PR TITLE
Multi dataset

### DIFF
--- a/blik/datablocks/abstractblocks/datablock.py
+++ b/blik/datablocks/abstractblocks/datablock.py
@@ -13,14 +13,14 @@ class DataBlock(ABC, metaclass=MetaBlock):
     """
     _depiction_modes = {}
 
-    def __init__(self, *, name=None, volume=None, dataset=None, multiblock=None, view_of=None, file_path=''):
+    def __init__(self, *, name=None, volume=None, datasets=set(), multiblock=None, view_of=None, file_path=''):
         self._multiblock = multiblock
         self._view_of = view_of
         if name is None:
             name = token_hex(8)
         # set even in case of view/multiblock, as fallback
         self._name = name
-        self._dataset = dataset
+        self._datasets = datasets
         self._volume = volume
         self._file_path = file_path
         self._depictors = []
@@ -41,12 +41,8 @@ class DataBlock(ABC, metaclass=MetaBlock):
         return self.view_of.multiblock
 
     @property
-    def dataset(self):
-        return self.parent._dataset
-
-    @dataset.setter
-    def dataset(self, dataset):
-        self.parent._dataset = dataset
+    def datasets(self):
+        return self.parent._datasets
 
     @property
     def name(self):
@@ -79,9 +75,10 @@ class DataBlock(ABC, metaclass=MetaBlock):
 
     def add_to_same_volume(self, datablocks):
         datablocks = listify(datablocks)
-        self.dataset.extend(datablocks)
         for db in datablocks:
             db.volume = self.volume
+        for dataset in self.datasets:
+            dataset.extend(datablocks)
 
     def __view__(self, **kwargs):
         return type(self)(view_of=self.view_of, **kwargs)

--- a/blik/dataset.py
+++ b/blik/dataset.py
@@ -72,10 +72,7 @@ class DataSet:
     def _hook_onto_datablocks(self, datablocks):
         if not self.is_view():
             for db in datablocks:
-                # TODO: this is broken. Needs to be fixed, if possible.
-                # if db.dataset is not None:
-                    # raise RuntimeError('Datablocks cannot be assigned to a new DataSet.')
-                db.dataset = self
+                db.datasets.add(self)
 
     def _nested(self, as_list=False):
         nested = defaultdict(list)
@@ -193,12 +190,18 @@ class DataSet:
     def remove(self, item):
         self._data.remove(item)
 
-    # TODO: adding dataset needs some more work. Name clashing and similar issues need to be solved.
-    # def __add__(self, other):
-        # if isinstance(other, DataSet):
-            # return DataSet(self._data + self._sanitize(other))
-        # else:
-            # return NotImplemented
+    def __add__(self, other):
+        if isinstance(other, (DataSet, list)):
+            return DataSet(self._data + self._sanitize(other))
+        else:
+            return NotImplemented
+
+    def __iadd__(self, other):
+        if isinstance(other, (DataSet, list)):
+            self.extend(other)
+            return self
+        else:
+            return NotImplemented
 
     # REPRESENTATION
     def __shape_repr__(self):

--- a/blik/dataset.py
+++ b/blik/dataset.py
@@ -53,6 +53,10 @@ class DataSet:
     def is_view(self):
         return self.view_of is not self
 
+    def copy(self, new_name=None):
+        cp = DataSet(self, name=new_name)
+        return cp
+
     def _sanitize(self, iterable, deduplicate=True):
         listified = listify(iterable)
         for item in listified:

--- a/blik/depictors/napari/particledepictor.py
+++ b/blik/depictors/napari/particledepictor.py
@@ -65,10 +65,17 @@ class ParticleDepictor(NapariDepictor):
         return all_vectors
 
     def set_rescale(self):
+        """
+        dig through all the datablocks sharing this volume. If any are images, use their shape
+        to rescale the normalized coords of the particles to the original ones
+        """
+        if self.datablock.volume is None:
+            # None volumes are by definition single datablocks so we can should skip them
+            return
         pos = self.datablock.positions.data
         if 0 <= pos.min().item() <= pos.max().item() <= 1:
-            dataset = self.datablock.dataset
-            if dataset:
+            datasets = self.datablock.datasets
+            for dataset in datasets:
                 same_volume = dataset.volumes[self.datablock.volume]
                 from ...datablocks import ImageBlock
                 for db in same_volume:


### PR DESCRIPTION
So far, datablocks could only have a single dataset. this simple change should allow datasets to share datablocks without encountering weird issues with inconsistent states (datablocks need to keep track of their dataset(s) for a few helpful things).

This should also fix any issues we had with the ability of appending/removing/merging datasets.

Also, you can now merge datasets with `+` or `+=` :)

(This should help with operations such as the one proposed in #116 )