### PR TITLE
Lazy loading with dask

### DIFF
--- a/blik/__main__.py
+++ b/blik/__main__.py
@@ -14,14 +14,12 @@ import click
               help='only show the list of files that would be read')
 @click.option('--strict', is_flag=True,
               help='immediately fail if a matched path cannot be read')
-@click.option('--mmap', is_flag=True,
-              help='open file in memory map mode (if possible)')
 @click.option('--lazy', is_flag=True, default=True,
               help='read data lazily (if possible)')
 @click.option('--no-show', is_flag=True,
               help='only create the DataSet, without showing the data in napari')
 @click.version_option()
-def cli(paths, mode, name_regex, pixel_size, dry_run, strict, name, mmap, lazy, no_show):
+def cli(paths, mode, name_regex, pixel_size, dry_run, strict, name, lazy, no_show):
     """
     Blik command line interface.
 
@@ -67,7 +65,6 @@ def cli(paths, mode, name_regex, pixel_size, dry_run, strict, name, mmap, lazy, 
                      name_regex=name_regex,
                      pixel_size=pixel_size,
                      strict=strict,
-                     mmap=mmap,
                      lazy=lazy,
                      )
 

--- a/blik/datablocks/abstractblocks/datablock.py
+++ b/blik/datablocks/abstractblocks/datablock.py
@@ -122,11 +122,8 @@ class DataBlock(ABC, metaclass=MetaBlock):
 
     def __short_repr__(self):
         # needed so this works for lazy multiblocs and simpleblocks
-        shape = ''
-        if getattr(self, '_loaded', False):
-            shape = self.__shape_repr__()
         return (f'{type(self).__name__}{self.__view_repr__()}'
-                f'{self.__name_repr__()}{shape}')
+                f'{self.__name_repr__()}{self.__shape_repr__()}')
 
     def __repr__(self):
         return self.__short_repr__()

--- a/blik/datablocks/abstractblocks/multiblock.py
+++ b/blik/datablocks/abstractblocks/multiblock.py
@@ -43,7 +43,3 @@ class MultiBlock(DataBlock, metaclass=MetaMultiBlock):
             sliced = block.__getitem__(key)
             subslices[f'{block_name}_data'] = sliced
         return self.__view__(**subslices)
-
-    @property
-    def _loaded(self):
-        return all(db._loaded for db in self.blocks)

--- a/blik/datablocks/simpleblocks/imageblock.py
+++ b/blik/datablocks/simpleblocks/imageblock.py
@@ -1,6 +1,7 @@
 import logging
 
 import numpy as np
+import dask.array as da
 
 from ..abstractblocks import SpatialBlock, SimpleBlock
 from ...depictors import ImageDepictor
@@ -18,7 +19,7 @@ class ImageBlock(SpatialBlock, SimpleBlock):
     _depiction_modes = {'default': ImageDepictor}
 
     def _data_setter(self, data):
-        data = np.asarray(data)  # asarray does not copy unless needed
+        data = da.asarray(data)
         if data.ndim < 2:
             raise ValueError('images must have at least 2 dimensions')
         if data.ndim == 2:

--- a/blik/io_/reading/em.py
+++ b/blik/io_/reading/em.py
@@ -18,7 +18,7 @@ def read_em(image_path, name_regex=None, lazy=True, **kwargs):
     name = guess_name(image_path, name_regex)
 
     header, data = emfile.read(image_path, mmap=True)
-    
+
     if lazy:
         data = da.from_array(data)
     else:

--- a/blik/io_/reading/em.py
+++ b/blik/io_/reading/em.py
@@ -2,6 +2,7 @@ import logging
 
 import emfile
 import dask.array as da
+import numpy as np
 
 from ...datablocks import ImageBlock
 from ..utils import guess_name
@@ -16,11 +17,12 @@ def read_em(image_path, name_regex=None, lazy=True, **kwargs):
     """
     name = guess_name(image_path, name_regex)
 
+    header, data = emfile.read(image_path, mmap=True)
+    
     if lazy:
-        header, data = emfile.read(image_path, mmap=True)
         data = da.from_array(data)
     else:
-        header, data = emfile.read(image_path)
+        data = np.asarray(data)
 
     pixel_size = header['OBJ']
 

--- a/blik/io_/reading/main.py
+++ b/blik/io_/reading/main.py
@@ -90,7 +90,6 @@ def read_files(*globs,
          name_regex=None,
          pixel_size=None,
          strict=False,
-         mmap=False,
          lazy=True,
          **kwargs):
     r"""
@@ -109,7 +108,6 @@ def read_files(*globs,
     File reading arguments:
         strict: if set to true, immediately fail if a matched filename cannot be read by Blik
     Performance arguments:
-        mmap: open file in memory map mode (if possible)
         lazy: read data lazily (if possible)
     """
     # if changing the signature of this function, change the one in `__main__.cli` as well!
@@ -123,7 +121,7 @@ def read_files(*globs,
         try:
             logger.info(f'attempting to read "{file}"')
             datablocks.extend(read_file(file, name_regex=name_regex, pixel_size=pixel_size,
-                                        mmap=mmap, lazy=lazy, **kwargs))
+                                        lazy=lazy, **kwargs))
         except ParseError as e:
             logger.info(f'failed to read "{file}": {e}')
             if strict:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ include_package_data = True
 install_requires =
     napari>=0.4.12
     numpy
+    dask
     pandas
     scipy
     pyqtgraph
@@ -45,7 +46,7 @@ install_requires =
     eulerangles==1.0.1
     mrcfile==1.3.0
     starfile==0.4.5
-    emfile==0.2
+    emfile==0.3
 
 
 [options.extras_require]


### PR DESCRIPTION
As mentioned in #120, dask is a better way to handle the lazy loading in napari. This PR changes all our lazy loading to use dask and simply let napari handle the work.

It works, but there's an issue: when using dask, contrast limits are automatically set to `0, 1` by napari. I'm not sure how to get around this... Is there a reasonable guess of the data range with mrc data, for example?